### PR TITLE
Add command-line processing for quick one-liners

### DIFF
--- a/processor.rb
+++ b/processor.rb
@@ -168,7 +168,7 @@ class Processor   #{{{1
     attr_reader :stack, :registers, :macros, :recording, :settings
     attr_accessor :base, :angle
 
-    def initialize settings_file=File.join(Dir.home, '.rpnrc')   #{{{2
+    def initialize settings_file   #{{{2
         @settings = Settings.new(settings_file)
         @stack = @settings.stack
         @registers = @settings.registers

--- a/rpn
+++ b/rpn
@@ -1,2 +1,2 @@
 #!/bin/bash
-ruby ~/projects/RPN/rpn.rb
+ruby ~/projects/RPN/rpn.rb "$@"

--- a/rpn.rb
+++ b/rpn.rb
@@ -9,7 +9,7 @@ processor = Processor.new
 
 if ARGV.length > 0
   answer = processor.execute(ARGV.join(' '))
-  puts processor.format(answer).colorize(processor.settings.color_normal)
+  puts processor.stack.map{|value| "#{processor.format(value)}" }.join(' ').colorize(processor.settings.color_normal)
   Clipboard.copy processor.format(answer).to_s unless answer.nil?
 else
   puts "RPN Calculator, ©2016, Phil Runninger ".colorize(processor.settings.color_title) + 

--- a/rpn.rb
+++ b/rpn.rb
@@ -7,42 +7,48 @@ require_relative 'processor'
 
 processor = Processor.new
 
-puts "RPN Calculator, ©2016, Phil Runninger ".colorize(processor.settings.color_title) + 
-  "#{'═' * (processor.console_columns - 57)} Enter ? for help.".colorize(processor.settings.color_help)
-input = ''
-begin
+if ARGV.length > 0
+  answer = processor.execute(ARGV.join(' '))
+  puts processor.format(answer).colorize(processor.settings.color_normal)
+  Clipboard.copy processor.format(answer).to_s unless answer.nil?
+else
+  puts "RPN Calculator, ©2016, Phil Runninger ".colorize(processor.settings.color_title) + 
+    "#{'═' * (processor.console_columns - 57)} Enter ? for help.".colorize(processor.settings.color_help)
+  input = ''
   begin
-    answer = processor.execute(input)
-  rescue Exception => exception
-    answer = nil
-    puts exception.message.colorize(processor.settings.color_error)
+    begin
+      answer = processor.execute(input)
+    rescue Exception => exception
+      answer = nil
+      puts exception.message.colorize(processor.settings.color_error)
+    end
+
+    prompt = ''
+
+    prompt += "Recording #{processor.recording}... ".colorize(processor.settings.color_error) unless processor.recording.nil?
+    prompt += "#{processor.macros.keys.join(', ')}  ".colorize(processor.settings.color_help) unless processor.macros == {}
+
+    prompt += processor.registers.map{|name, value|
+      name.colorize(processor.settings.color_register) +
+        '='.colorize(processor.settings.color_normal) +
+        processor.format(value).colorize(processor.settings.color_register)}.join(' ')
+    prompt += ' • '.colorize(processor.settings.color_help_heading) unless processor.registers.empty?
+
+    prompt += processor.stack.map{|value| "#{processor.format(value)}" }.join(' ').colorize(processor.settings.color_normal)
+    prompt += ' ' unless processor.stack.empty?
+
+    prompt += processor.radix.colorize(processor.settings.color_title) + ' ' unless processor.radix.empty?
+
+    prompt += "#{processor.angle}► ".colorize(processor.settings.color_title)
+
+    input = Readline.readline(prompt.strip, true)
+    Readline::HISTORY.pop if Readline::HISTORY.length>1 &&  Readline::HISTORY[-1] == Readline::HISTORY[-2]
+  end while input > ''
+
+  puts "#{'═' * (processor.console_columns - 23)} Thanks for using rpn.".colorize(processor.settings.color_help)
+  if !answer.nil?
+    Clipboard.copy processor.format(answer).to_s
+    puts processor.format(answer).colorize(processor.settings.color_normal) +
+      ' was copied to the clipboard.'.colorize(processor.settings.color_register)
   end
-
-  prompt = ''
-
-  prompt += "Recording #{processor.recording}... ".colorize(processor.settings.color_error) unless processor.recording.nil?
-  prompt += "#{processor.macros.keys.join(', ')}  ".colorize(processor.settings.color_help) unless processor.macros == {}
-
-  prompt += processor.registers.map{|name, value|
-    name.colorize(processor.settings.color_register) +
-    '='.colorize(processor.settings.color_normal) +
-    processor.format(value).colorize(processor.settings.color_register)}.join(' ')
-  prompt += ' • '.colorize(processor.settings.color_help_heading) unless processor.registers.empty?
-
-  prompt += processor.stack.map{|value| "#{processor.format(value)}" }.join(' ').colorize(processor.settings.color_normal)
-  prompt += ' ' unless processor.stack.empty?
-
-  prompt += processor.radix.colorize(processor.settings.color_title) + ' ' unless processor.radix.empty?
-
-  prompt += "#{processor.angle}► ".colorize(processor.settings.color_title)
-
-  input = Readline.readline(prompt.strip, true)
-  Readline::HISTORY.pop if Readline::HISTORY.length>1 &&  Readline::HISTORY[-1] == Readline::HISTORY[-2]
-end while input > ''
-
-puts "#{'═' * (processor.console_columns - 23)} Thanks for using rpn.".colorize(processor.settings.color_help)
-if !answer.nil?
-  Clipboard.copy processor.format(answer).to_s
-  puts processor.format(answer).colorize(processor.settings.color_normal) +
-    ' was copied to the clipboard.'.colorize(processor.settings.color_register)
 end

--- a/rpn.rb
+++ b/rpn.rb
@@ -5,13 +5,14 @@ require 'readline'
 require 'clipboard'
 require_relative 'processor'
 
-processor = Processor.new
 
 if ARGV.length > 0
+  processor = Processor.new nil
   answer = processor.execute(ARGV.join(' '))
   puts processor.stack.map{|value| "#{processor.format(value)}" }.join(' ').colorize(processor.settings.color_normal)
   Clipboard.copy processor.format(answer).to_s unless answer.nil?
 else
+  processor = Processor.new File.join(Dir.home, '.rpnrc')
   puts "RPN Calculator, ©2016, Phil Runninger ".colorize(processor.settings.color_title) + 
     "#{'═' * (processor.console_columns - 57)} Enter ? for help.".colorize(processor.settings.color_help)
   input = ''

--- a/rpn.rb
+++ b/rpn.rb
@@ -9,11 +9,11 @@ require_relative 'processor'
 if ARGV.length > 0
   processor = Processor.new nil
   answer = processor.execute(ARGV.join(' '))
-  puts processor.stack.map{|value| "#{processor.format(value)}" }.join(' ').colorize(processor.settings.color_normal)
+  puts processor.stack.map{|value| "#{processor.format(value)}" }.join('  ').colorize(processor.settings.color_normal)
   Clipboard.copy processor.format(answer).to_s unless answer.nil?
 else
   processor = Processor.new File.join(Dir.home, '.rpnrc')
-  puts "RPN Calculator, ©2016, Phil Runninger ".colorize(processor.settings.color_title) + 
+  puts "RPN Calculator, ©2016, Phil Runninger ".colorize(processor.settings.color_title) +
     "#{'═' * (processor.console_columns - 57)} Enter ? for help.".colorize(processor.settings.color_help)
   input = ''
   begin

--- a/settings.rb
+++ b/settings.rb
@@ -5,6 +5,7 @@ class Settings
 
   def initialize(settings_file)
     @settings_file = settings_file
+    @hash = {}
     begin
       @hash = JSON.parse(File.read(settings_file)) if File.exist?(settings_file)
     rescue Exception
@@ -13,7 +14,7 @@ class Settings
   end
 
   def write
-    File.open(@settings_file,'w') {|f| f.write(JSON.pretty_generate(@hash))}
+    File.open(@settings_file,'w') {|f| f.write(JSON.pretty_generate(@hash))} unless @settings_file.nil?
   end
 
   def stack= stack


### PR DESCRIPTION
Implements #12. As mentioned in the issue, certain operators can't be entered without escaping. These are: `*`, `**`, `\`, `&`, `|`, `<<`, `>>`, `~`, register commands (which use `>` and `<`), and macro definitions (which use `(` and `)`).

A better, but a little clumsier, approach when using these operators is to put the calculation into a single string, like so:
```
prompt$ rpn "6 7 *"
42
```